### PR TITLE
Added setting to disable creation of Ingress object

### DIFF
--- a/releases/R2024a/matlab-prodserver/Chart.yaml
+++ b/releases/R2024a/matlab-prodserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "R2024a"
 description: MATLAB Production Server Helm chart for Kubernetes
 name: matlab-prodserver-k8s
-version: 1.0.2
+version: 1.0.3

--- a/releases/R2024a/matlab-prodserver/templates/mps-1-service-ingress.yaml
+++ b/releases/R2024a/matlab-prodserver/templates/mps-1-service-ingress.yaml
@@ -19,6 +19,7 @@ spec:
   type: ClusterIP
 
 ---
+{{- if .Values.global.ingressController.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -55,6 +56,7 @@ spec:
             name: matlab-production-server
             port:
               number: 9910
+{{- end }}
 
 ---
 {{ if and (.Values.optionalSettings.Prometheus.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}

--- a/releases/R2024a/matlab-prodserver/values.yaml
+++ b/releases/R2024a/matlab-prodserver/values.yaml
@@ -10,6 +10,7 @@ global:
     registry: ""
     pullSecret: ""
   ingressController:
+    enabled: true  # Create 'Ingress' API object
     # Nginx settings (optional)
     name: nginx
     annotations: {}

--- a/values-overrides.yaml
+++ b/values-overrides.yaml
@@ -12,6 +12,7 @@ global:
 
   # Ingress settings (optional)
   ingressController:
+    enabled: true  # Create 'Ingress' API object
     name: nginx
     annotations:
       nginx.ingress.kubernetes.io/affinity: "cookie"


### PR DESCRIPTION
This was requested to avoid hijacking of root context by the Ingress object.
Default set to true to avoid mid-release (R2024a) behavior change.
Plan to change default value to false for the R2024b chart.